### PR TITLE
Correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Java Source codes for Wi-Fi Calling Extension (to be released)
  - Price | Free
  - Decompiling | Not Allowed
 
-This extension works on all MIT App Inventor Offsprings expect ThunkableX
+This extension works on all MIT App Inventor Offsprings
 
 Read License agreement before using, you agree to abide by it by using the extension
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Java Source codes for Wi-Fi Calling Extension (to be released)
  - Price | Free
- - Decompiling | Not Allowed
 
 This extension works on all MIT App Inventor Offsprings
 


### PR DESCRIPTION
ThunkableX Not a distro of appinventor (Thunkable classic was, though deprecated now) and why would someone even decompile a open-source extension, you can just add a MIT license here.